### PR TITLE
Added support for HTTPS

### DIFF
--- a/lib/intermine/service.rb
+++ b/lib/intermine/service.rb
@@ -165,6 +165,9 @@ module InterMine
             @root_path = root_uri.path
 
             @http = Net::HTTP.new(root_uri.host, root_uri.port)
+            if root_uri.scheme == 'https'
+                @http.use_ssl = true
+            end
 
             v_path = @root + VERSION_PATH
             begin

--- a/lib/intermine/version.rb
+++ b/lib/intermine/version.rb
@@ -3,6 +3,7 @@ module Intermine
     # Webservice Client Version number
     #
     # Changes:
+    #   1.05.00 - Add support for HTTPS
     #   1.03.00 - Add support for indexed sequence service
     #   1.02.00 - Allow the lazy fetching to be optional
     #   1.01.01 - Improved lazy reference fetching
@@ -21,5 +22,5 @@ module Intermine
     #   0.98.09 - Major changes to results - now with thorough-going Enumerable support
     #   0.98.08 - Added column summary support
     #
-    VERSION = "1.03.00"
+    VERSION = "1.05.00"
 end


### PR DESCRIPTION
Hello @intermine team (cc @yochannah @joshkh @justinccdev @julie-sullivan).

We were recently notified by a ThaleMine user that they were unable to use the Ruby API interface to InterMine, with our ThaleMine webapp.

Here is the error they reported:
```
---- Environment ----
Ruby 2.3.3
Intermine gem version 1.04.00

---- Example Code ----
require "rubygems"
require "intermine/service"
service = Service.new("https://apps.araport.org:443/thalemine")

service.new_query("Gene").
select(["primaryIdentifier", "symbol", "briefDescription", "isObsolete"]).
order_by("primaryIdentifier", "ASC").
limit(10).
each_row { |r| puts r}

---- Error ----
/home/andy/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/intermine-1.04.00/lib/intermine/service.rb:173:in `rescue in initialize': Error fetching version at https://apps.araport.org:443/thalemine/service/version: 400 (InterMine::ServiceError)
from /home/andy/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/intermine-1.04.00/lib/intermine/service.rb:170:in `initialize'
from ./araport_example.rb:17:in `new'
from ./araport_example.rb:17:in `<main>'
```

From examining this error, it seems that the Ruby interface does not have support for mines being served via HTTPS. (there is a brief discussion in this thread as well: https://lists.intermine.org/pipermail/dev/2016-February/003675.html)

This PR adds the necessary code changes to the `service`, `results` and `lists` interfaces, appropriately enabling the `use_ssl` opt for mines using the HTTPS scheme.

Please review and accept the PR at your earliest convenience.

Thank you!

Regards,
Vivek